### PR TITLE
Drupal block and context caching.

### DIFF
--- a/web/modules/custom/cache_exercise/cache_exercise.info.yml
+++ b/web/modules/custom/cache_exercise/cache_exercise.info.yml
@@ -1,0 +1,7 @@
+name: 'Cache Exercise'
+type: module
+description: 'Displaying different caching techniques.'
+core_version_requirement: ^10
+package: Custom
+dependencies:
+  - drupal:node

--- a/web/modules/custom/cache_exercise/src/Plugin/Block/LatestArticlesBlock.php
+++ b/web/modules/custom/cache_exercise/src/Plugin/Block/LatestArticlesBlock.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\cache_exercise\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+
+/**
+ * Provides a 'Latest Articles' Block.
+ *
+ * @Block(
+ *   id = "latest_articles_block",
+ *   admin_label = @Translation("Latest Articles Block")
+ * )
+ */
+class LatestArticlesBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new LatestArticlesBlock.
+   *
+   * @param array $configuration
+   *   A configuration array containing plugin instance configuration.
+   * @param string $plugin_id
+   *   The plugin ID for the block.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    // Load the last 3 published article nodes.
+    $storage = $this->entityTypeManager->getStorage('node');
+    $query = $storage->getQuery()
+      ->condition('status', 1)
+      ->condition('type', 'article')
+      ->sort('created', 'DESC')
+      ->range(0, 3)
+      ->accessCheck(TRUE);
+    $nids = $query->execute();
+    // var_dump($nids);
+    $titles = [];
+    if (!empty($nids)) {
+      $nodes = $storage->loadMultiple($nids);
+      foreach ($nodes as $node) {
+        $titles[] = $node->toLink()->toString();
+      }
+    }
+
+    return [
+      '#theme' => 'item_list',
+      '#items' => $titles,
+      '#cache' => [
+        // 'tags' => array_map(fn($nid) => "node:$nid", $nids),
+        'tags' => array_merge(array_map(fn($nid) => "node:$nid", $nids), ['node_list']),
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION

Activity

Create a custom block displaying the title of last 3 articles created on the site as an item list. The block ouput should be cached to render the content & get invalidated automatically once the title for one of the nodes is updated.
Steps

    Create a custom block to render the title of last 3 articles
    Add #cache to it with the node ids of the articles being rendered



Activity

Extend the block created above to render email address of the current user.
Steps

Add cache context for current user to the block's build() function.
