### PR TITLE
Drupal caching using context.

### DIFF
--- a/web/modules/custom/cache_exercise/cache_exercise.services.yml
+++ b/web/modules/custom/cache_exercise/cache_exercise.services.yml
@@ -1,0 +1,6 @@
+services:
+  cache_context.preferred_category:
+    class: Drupal\cache_exercise\Cache\Context\PreferredCategoryCacheContext
+    arguments: ['@current_user', '@entity_type.manager']
+    tags:
+      - { name: cache.context }

--- a/web/modules/custom/cache_exercise/src/Cache/Context/PreferredCategoryCacheContext.php
+++ b/web/modules/custom/cache_exercise/src/Cache/Context/PreferredCategoryCacheContext.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\cache_exercise\Cache\Context;
+
+use Drupal\Core\Cache\Context\CacheContextInterface;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Provides a custom cache context for the preferred category.
+ */
+class PreferredCategoryCacheContext implements CacheContextInterface {
+
+  protected AccountInterface $currentUser;
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  public function __construct(AccountInterface $currentUser, EntityTypeManagerInterface $entityTypeManager) {
+    $this->currentUser = $currentUser;
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContext() {
+
+    if ($this->currentUser->isAnonymous()) {
+      return 'none';
+    }
+
+    // Load the user entity.
+    $user = $this->entityTypeManager->getStorage('user')->load($this->currentUser->id());
+    if ($user && !$user->get('field_preferred_category')->isEmpty()) {
+      return (string) $user->get('field_preferred_category')->target_id;
+    }
+
+    return 'none';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata() {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getLabel() {
+    return t('Preferred category');
+  }
+}

--- a/web/modules/custom/cache_exercise/src/Plugin/Block/PreferredCategoryArticlesBlock.php
+++ b/web/modules/custom/cache_exercise/src/Plugin/Block/PreferredCategoryArticlesBlock.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Drupal\cache_exercise\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Cache\Cache;
+
+/**
+ * Provides a block that displays articles from the user's preferred category.
+ *
+ * @Block(
+ *   id = "preferred_category_articles",
+ *   admin_label = @Translation("Preferred Category Articles"),
+ *   category = @Translation("Custom")
+ * )
+ */
+class PreferredCategoryArticlesBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  protected EntityTypeManagerInterface $entityTypeManager;
+  protected AccountInterface $currentUser;
+
+  /**
+   * Constructs the block.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entityTypeManager, AccountInterface $currentUser) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entityTypeManager;
+    $this->currentUser = $currentUser;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    // Load the user entity.
+    $user = $this->entityTypeManager->getStorage('user')->load($this->currentUser->id());
+    if (!$user || $user->get('field_preferred_category')->isEmpty()) {
+      return [
+        '#markup' => $this->t('You have not set a preferred category.'),
+        '#cache' => ['contexts' => ['user']],
+      ];
+    }
+
+    $category_id = $user->get('field_preferred_category')->target_id;
+
+    // Load articles matching the preferred category.
+    $query = $this->entityTypeManager->getStorage('node')->getQuery()
+      ->condition('type', 'article')
+      ->condition('field_category', $category_id)
+      ->condition('status', 1)
+      ->sort('created', 'DESC')
+      ->range(0, 5)
+      ->accessCheck(TRUE);
+
+    $nids = $query->execute();
+
+    if (empty($nids)) {
+      return [
+        '#markup' => $this->t('No articles found in your preferred category.'),
+        '#cache' => [
+          'contexts' => ['user', 'preferred_category'],
+        ],
+      ];
+    }
+
+    $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
+    $items = [];
+
+    foreach ($nodes as $node) {
+      $items[] = [
+        '#type' => 'link',
+        '#title' => $node->label(),
+        '#url' => $node->toUrl(),
+      ];
+    }
+
+    return [
+      '#theme' => 'item_list',
+      '#items' => $items,
+      '#cache' => [
+        'contexts' => ['user', 'preferred_category'],
+      ],
+    ];
+  }
+}


### PR DESCRIPTION
    Add a preferred category field (taxonomy term reference) on user profile.
    Create article content type and include the category field in there
    Create a custom block which shows articles from the preferred category selected on user account.
    Handle cache scenarios using a custom cache context